### PR TITLE
Implemented the /profile API for user profile data parsing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.sonarqube'
-apply plugin: 'net.saliman.cobertura'
 apply plugin: 'com.github.ksoichiro.console.reporter'
+apply plugin: 'jacoco-android'
+
 
 android {
     signingConfigs {
@@ -13,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 27
         versionCode 42
-        versionName "1.0.4"
+        versionName project.habitatVersionName
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -26,6 +27,14 @@ android {
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
+        }
+    }
+
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
         }
     }
 }
@@ -49,6 +58,8 @@ dependencies {
     // Dependencies for local unit tests
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.json:json:20140107'
+
     // Google stuff
     implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation 'com.android.support:design:27.1.0'
@@ -74,38 +85,44 @@ dependencies {
     apply plugin: 'com.google.gms.google-services'
 }
 
+consoleReporter {
+    jacoco {
+        reportFile = new File("${project.buildDir}/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml")
+    }
+}
+
+jacocoAndroidUnitTestReport {
+
+    excludes += ['**/*Activity.*',
+                 '**/*Fragment.*',
+                 '**/*DbHelper.*',
+                 '**/*BackupNotifications.*',
+                 '**/*GooglePlayServicesHelper.*',
+                 '**/*KeyStoreHelper.*',
+                 '**/*InputStreamVolleyRequest.*',
+                 '**/*PaletteHelper.*',
+                 '**/*UserCredentialsManager.*',
+                 '**/adapters/**',
+                 '**/base/**',
+                 '**/dialogs/**',
+                 '**/fcm/**',
+                 '**/jobservices/**',
+                 '**/participate/**',
+                 '**/preferences/**',
+                 '**/provider/**',
+                 '**/splash/**',
+                 '**/zautomation/**']
+}
+
 sonarqube {
     properties {
         property "sonar.projectName", "Habitat"
         property "sonar.projectKey", "android_habitat"
         property "sonar.sources","src/main/java"
         property "sonar.language","java"
+        property "sonar.java.coveragePlugin", "jacoco"
+        property "sonar.jacoco.reportPaths","${project.buildDir}/jacoco/testDebugUnitTest.exec"
     }
 }
 
-
-cobertura {
-    coverageIncludes = ['.*no.aegisdynamics.habitat.automationsadd.*',
-                        '.*no.aegisdynamics.habitat.automations.*',
-                        '.*no.aegisdynamics.habitat.backup.*',
-                        '.*no.aegisdynamics.habitat.controller',
-                        '.*no.aegisdynamics.habitat.dashboard.*',
-                        '.*no.aegisdynamics.habitat.data.*',
-                        '.*no.aegisdynamics.habitat.devicedetail',
-                        '.*no.aegisdynamics.habitat.devices.*',
-                        '.*no.aegisdynamics.habitat.locationadd.*',
-                        '.*no.aegisdynamics.habitat.locations.*',
-                        '.*no.aegisdynamics.habitat.notifications.*',
-                        '.*no.aegisdynamics.habitat.setup.*',
-                        '.*no.aegisdynamics.habitat.util.*']
-
-    coverageExcludes = ['.*Activity.*',
-                        '.*Fragment.*',
-                        '.*DbHelper.*',
-                        '.*BackupNotifications.*',
-                        '.*GooglePlayServicesHelper.*',
-                        '.*KeyStoreHelper.*',
-                        '.*InputStreamVolleyRequest.*',
-                        '.*PaletteHelper.*',
-                        '.*UserCredentialsManager.*']
-}
+tasks.sonarqube.dependsOn jacocoTestReport

--- a/app/src/main/java/no/aegisdynamics/habitat/backup/BackupFragment.java
+++ b/app/src/main/java/no/aegisdynamics/habitat/backup/BackupFragment.java
@@ -168,7 +168,7 @@ public class BackupFragment extends Fragment implements BackupContract.View,
             View view = getView();
             if (view != null) {
                 RelativeLayout emptyBackupLayout = view.findViewById(R.id.backups_empty_layout);
-                if (backups.size() > 0) {
+                if (!backups.isEmpty()) {
                     emptyBackupLayout.setVisibility(View.GONE);
                 } else {
                     emptyBackupLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/no/aegisdynamics/habitat/data/notifications/NotificationsServiceApiImpl.java
+++ b/app/src/main/java/no/aegisdynamics/habitat/data/notifications/NotificationsServiceApiImpl.java
@@ -25,6 +25,7 @@ import java.util.TimeZone;
 
 import no.aegisdynamics.habitat.R;
 import no.aegisdynamics.habitat.util.NotificationTimestampComparator;
+import no.aegisdynamics.habitat.util.VolleyResponseHelper;
 import no.aegisdynamics.habitat.zautomation.ZWayNetworkHelper;
 import no.aegisdynamics.habitat.util.RequestQueueSingelton;
 
@@ -56,18 +57,11 @@ public class NotificationsServiceApiImpl implements NotificationsServiceApi {
 
                     @Override
                     public void onResponse(JSONObject response) {
-                        try {
-                            // Verify response code
-                            int responseCode = response.getInt("code");
-                            if (responseCode == 200) {
-                                callback.onLoaded(true);
-                            } else {
-                                callback.onError(context.getString(R.string.error_generic));
-                            }
-
-                        } catch (JSONException e) {
-                            callback.onError(e.getMessage());
-                            e.printStackTrace();
+                        // Verify response code
+                        if (VolleyResponseHelper.hasResponseReturnedOK(response)) {
+                            callback.onLoaded(true);
+                        } else {
+                            callback.onError(context.getString(R.string.error_generic));
                         }
                     }
                 }, new Response.ErrorListener() {
@@ -113,18 +107,10 @@ public class NotificationsServiceApiImpl implements NotificationsServiceApi {
 
                         @Override
                         public void onResponse(JSONObject response) {
-                            try {
-                                // Verify response code
-                                int responseCode = response.getInt("code");
-                                if (responseCode == 200) {
-                                    callback.onLoaded(true);
-                                } else {
-                                    callback.onError(context.getString(R.string.error_generic));
-                                }
-
-                            } catch (JSONException e) {
-                                callback.onError(e.getMessage());
-                                e.printStackTrace();
+                            if (VolleyResponseHelper.hasResponseReturnedOK(response)) {
+                                callback.onLoaded(true);
+                            } else {
+                                callback.onError(context.getString(R.string.error_generic));
                             }
                         }
                     }, new Response.ErrorListener() {
@@ -170,8 +156,7 @@ public class NotificationsServiceApiImpl implements NotificationsServiceApi {
                         List<Notification> notifications = new ArrayList<>();
                         try {
                             // Verify response code
-                            int responseCode = response.getInt("code");
-                            if (responseCode == 200) {
+                            if (VolleyResponseHelper.hasResponseReturnedOK(response)) {
 
                                 JSONObject dataObjects = response.getJSONObject("data");
                                 JSONArray notificationsArray = dataObjects.getJSONArray("notifications");

--- a/app/src/main/java/no/aegisdynamics/habitat/data/profile/Profile.kt
+++ b/app/src/main/java/no/aegisdynamics/habitat/data/profile/Profile.kt
@@ -5,6 +5,7 @@ package no.aegisdynamics.habitat.data.profile
  */
 
 class Profile(val id: Int,
+              val userName: String?,
               val name: String?,
               val email: String?,
               val dashboardDevices: List<String>)

--- a/app/src/main/java/no/aegisdynamics/habitat/data/profile/ProfileDataHelper.java
+++ b/app/src/main/java/no/aegisdynamics/habitat/data/profile/ProfileDataHelper.java
@@ -1,0 +1,47 @@
+package no.aegisdynamics.habitat.data.profile;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class for parsing profile data from JSON API.
+ */
+public class ProfileDataHelper {
+
+    private ProfileDataHelper() {
+        // Empty constructor
+    }
+
+    /**
+     * Parse profile data from JSONObject.
+     * @param dataObject JSONObject containing profile data from Z-Way API
+     * @return valid user Profile object.
+     */
+    public static Profile getProfileFromJsonData(JSONObject dataObject) {
+
+        try {
+            int profileId = dataObject.getInt("id");
+            String profileUserName = dataObject.getString("login");
+            String profileEmail = dataObject.getString("email");
+            String profileName = dataObject.getString("name");
+
+            // parse dashboard devices
+            JSONArray dashboardDevices = dataObject.getJSONArray("dashboard");
+            List<String> dashboardDevicesList = new ArrayList<>();
+            for (int i = 0; i < dashboardDevices.length(); i++) {
+                dashboardDevicesList.add(dashboardDevices.getString(i));
+            }
+
+            return new Profile(profileId, profileUserName, profileName, profileEmail,
+                    dashboardDevicesList);
+        } catch (JSONException ex) {
+            return null;
+        }
+
+
+    }
+}

--- a/app/src/main/java/no/aegisdynamics/habitat/util/VolleyResponseHelper.java
+++ b/app/src/main/java/no/aegisdynamics/habitat/util/VolleyResponseHelper.java
@@ -1,0 +1,23 @@
+package no.aegisdynamics.habitat.util;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Helper class for Volley response handling
+ */
+public class VolleyResponseHelper {
+
+    private VolleyResponseHelper() {
+        // empty constructor
+    }
+
+    public static boolean hasResponseReturnedOK(JSONObject response) {
+        try {
+            int responseCode = response.getInt("code");
+            return responseCode == 200;
+        } catch (JSONException ex) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/no/aegisdynamics/habitat/zautomation/ZWayNetworkHelper.java
+++ b/app/src/main/java/no/aegisdynamics/habitat/zautomation/ZWayNetworkHelper.java
@@ -162,7 +162,7 @@ public class ZWayNetworkHelper implements DeviceDataContract {
     }
 
     public static String getZwayProfileUrl(Context context) {
-        return String.format("%s%s/ZAutomation/api/v1/profiles", getURLPrefix(context),
+        return String.format("%s%s/ZAutomation/api/v1/session", getURLPrefix(context),
                 getZWayServerHostname(context));
     }
 

--- a/app/src/test/java/no/aegisdynamics/habitat/dashboard/DashboardPresenterTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/dashboard/DashboardPresenterTest.java
@@ -121,7 +121,7 @@ public class DashboardPresenterTest {
         verify(mDashboardView).setProgressIndicator(true);
         verify(mProfileRepository).getProfile(any(String.class), mGetProfileCallbackCaptor.capture());
         mGetProfileCallbackCaptor.getValue().onProfileLoaded(new Profile(0, "admin",
-                "admin@mail.com", dashboardDevices));
+                "Administrator", "admin@mail.com", dashboardDevices));
 
         verify(mDashboardView).onDashboardDevicesRetrieved(dashboardDevices);
 

--- a/app/src/test/java/no/aegisdynamics/habitat/data/device/APIDeviceProviderRepositoryTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/data/device/APIDeviceProviderRepositoryTest.java
@@ -1,0 +1,103 @@
+package no.aegisdynamics.habitat.data.device;
+
+import android.content.Context;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the APIDeviceProviderRepositoryTest
+ */
+public class APIDeviceProviderRepositoryTest {
+    private static final String DEVICE_ID = "device_1";
+    private static final String DEVICE_TITLE = "Device 1";
+    private static final String DEVICE_TYPE = "device";
+    private static final String DEVICE_LOCATION = "room";
+    private static final int DEVICE_LOCATION_ID = 1;
+    private static final int DEVICE_CREATOR_ID = 2;
+    private static final String[] DEVICE_TAGS = new String[]{"Tag 1", "Tag2"};
+    private static final String DEVICE_STATUS = "on";
+    private static final int DEVICE_MIN_VALUE = 0;
+    private static final int DEVICE_MAX_VALUE = 100;
+    private static final String DEVICE_STATUS_NOTATION = "celsius";
+    private static final String DEVICE_PROBE_TITLE = "Temperature";
+    private static final String DEVICE_ICON_NAME = "deviceicon";
+
+    private static final Device DEVICE = new Device(DEVICE_ID, DEVICE_TITLE, DEVICE_TYPE, DEVICE_LOCATION,
+            DEVICE_LOCATION_ID, DEVICE_CREATOR_ID, DEVICE_TAGS, DEVICE_STATUS, DEVICE_MIN_VALUE,
+            DEVICE_MAX_VALUE, DEVICE_STATUS_NOTATION, DEVICE_PROBE_TITLE, DEVICE_ICON_NAME);
+
+    private static List<Device> DEVICES;
+
+    @Mock
+    Context context;
+
+    @Mock
+    DevicesServiceApi serviceApi;
+
+    @Mock
+    DevicesRepository.LoadDevicesCallback mockedLoadDeviceCallback;
+
+    @Mock
+    DevicesRepository.GetDeviceCallback mockedGetDeviceCallback;
+
+    @Captor
+    private ArgumentCaptor<DevicesServiceApi.DevicesServiceCallback> devicesServiceCallbackCaptor;
+
+    private DevicesRepository devicesRepository;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        devicesRepository = new APIDeviceProviderRepository(serviceApi, context);
+        DEVICES = new ArrayList<>();
+        DEVICES.add(DEVICE);
+    }
+
+    @Test
+    public void getDevices_showSuccess() {
+        devicesRepository.getDevices(mockedLoadDeviceCallback);
+        verify(serviceApi).getAllDevices(eq(context), devicesServiceCallbackCaptor.capture());
+        devicesServiceCallbackCaptor.getValue().onLoaded(DEVICES);
+
+        verify(mockedLoadDeviceCallback).onDevicesLoaded(eq(DEVICES));
+    }
+
+    @Test
+    public void getDevices_showError() {
+        devicesRepository.getDevices(mockedLoadDeviceCallback);
+        verify(serviceApi).getAllDevices(eq(context), devicesServiceCallbackCaptor.capture());
+        devicesServiceCallbackCaptor.getValue().onError("error");
+
+        verify(mockedLoadDeviceCallback).onDevicesLoadError(eq("error"));
+    }
+
+    @Test
+    public void getDevice_showSuccess() {
+        devicesRepository.getDevice(DEVICE.getId(), mockedGetDeviceCallback);
+        verify(serviceApi).getDevice(eq(context), eq(DEVICE.getId()), devicesServiceCallbackCaptor.capture());
+        devicesServiceCallbackCaptor.getValue().onLoaded(DEVICE);
+
+        verify(mockedGetDeviceCallback).onDeviceLoaded(eq(DEVICE));
+    }
+
+    @Test
+    public void getDevice_showError() {
+        devicesRepository.getDevice(DEVICE.getId(), mockedGetDeviceCallback);
+        verify(serviceApi).getDevice(eq(context), eq(DEVICE.getId()), devicesServiceCallbackCaptor.capture());
+        devicesServiceCallbackCaptor.getValue().onError("error");
+
+        verify(mockedGetDeviceCallback).onDeviceLoadError(eq("error"));
+    }
+}

--- a/app/src/test/java/no/aegisdynamics/habitat/data/location/APILocationProviderRepositoryTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/data/location/APILocationProviderRepositoryTest.java
@@ -16,6 +16,10 @@ import java.util.List;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
+/**
+ * Unit tests for the APILocationProviderRepository class.
+ */
+
 public class APILocationProviderRepositoryTest {
 
     private APILocationProviderRepository mLocationRepository;

--- a/app/src/test/java/no/aegisdynamics/habitat/data/profile/ProfileDataHelperTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/data/profile/ProfileDataHelperTest.java
@@ -1,0 +1,45 @@
+package no.aegisdynamics.habitat.data.profile;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
+/**
+ * Unit tests for the ProfileDataHelper class.
+ */
+public class ProfileDataHelperTest {
+
+    @Test
+    public void parseProfileData_returnProfile() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        JSONObject profileData = new JSONObject();
+        JSONArray dashboardArray = new JSONArray();
+
+        profileData.put("id", 1);
+        profileData.put("login", "user");
+        profileData.put("name", "User");
+        profileData.put("email", "user@domain.com");
+
+        dashboardArray.put("device-1");
+        dashboardArray.put("device-2");
+
+        profileData.put("dashboard", dashboardArray);
+
+        jsonObject.put("data", profileData);
+
+        Profile userProfile = ProfileDataHelper.getProfileFromJsonData(profileData);
+
+        assertNotNull(userProfile);
+        assertEquals(userProfile.getId(), 1);
+        assertEquals(userProfile.getUserName(), "user");
+        assertEquals(userProfile.getEmail(), "user@domain.com");
+        assertEquals(userProfile.getName(), "User");
+
+        Profile badUserProfile = ProfileDataHelper.getProfileFromJsonData(jsonObject);
+        assertNull(badUserProfile);
+    }
+}

--- a/app/src/test/java/no/aegisdynamics/habitat/data/profile/ZWayAPIProfileRepositoryTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/data/profile/ZWayAPIProfileRepositoryTest.java
@@ -1,0 +1,62 @@
+package no.aegisdynamics.habitat.data.profile;
+
+import android.content.Context;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the ZWayAPIProfileRepository
+ */
+public class ZWayAPIProfileRepositoryTest {
+
+    private ZWayAPIProfileRepository mProfileRepository;
+
+    private static Profile PROFILE = new Profile(1, "user", "User", "user@domain.com",
+            new ArrayList<String>());
+
+    @Mock
+    private ProfileServiceApi serviceApi;
+
+    @Mock
+    private Context context;
+
+    @Mock
+    private ProfileRepository.GetProfileCallback mockedGetProfileCallback;
+
+    @Captor
+    private ArgumentCaptor<ProfileServiceApi.ProfileServiceCallback> callbackCaptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        mProfileRepository = new ZWayAPIProfileRepository(serviceApi, context);
+    }
+
+    @Test
+    public void getProfile_returnData() {
+        mProfileRepository.getProfile(PROFILE.getUserName(), mockedGetProfileCallback);
+        verify(serviceApi).getProfile(eq(context), eq(PROFILE.getUserName()), callbackCaptor.capture());
+        callbackCaptor.getValue().onLoaded(PROFILE);
+        verify(mockedGetProfileCallback).onProfileLoaded(eq(PROFILE));
+    }
+
+    @Test
+    public void getProfile_returnError() {
+        mProfileRepository.getProfile(PROFILE.getUserName(), mockedGetProfileCallback);
+        verify(serviceApi).getProfile(eq(context), eq(PROFILE.getUserName()), callbackCaptor.capture());
+        callbackCaptor.getValue().onError("error");
+        verify(mockedGetProfileCallback).onProfileLoadError(eq("error"));
+    }
+
+
+}

--- a/app/src/test/java/no/aegisdynamics/habitat/util/VolleyResponseHelperTest.java
+++ b/app/src/test/java/no/aegisdynamics/habitat/util/VolleyResponseHelperTest.java
@@ -1,0 +1,27 @@
+package no.aegisdynamics.habitat.util;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Unit tests for the VolleyResponse helper class
+ */
+public class VolleyResponseHelperTest {
+
+    @Test
+    public void isResponseOk_true() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("code", 200);
+        assertEquals(VolleyResponseHelper.hasResponseReturnedOK(jsonObject), true);
+
+        JSONObject errorJsonObject = new JSONObject();
+        errorJsonObject.put("code", 404);
+        assertEquals(VolleyResponseHelper.hasResponseReturnedOK(errorJsonObject), false);
+
+        JSONObject badJsonObject = new JSONObject();
+        badJsonObject.put("noCode", 200);
+        assertEquals(VolleyResponseHelper.hasResponseReturnedOK(badJsonObject), false);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+habitatVersionName=1.0.5


### PR DESCRIPTION
The Z-Way API exposes an undocumented /session point which contains user information of the currently authenticated user including dashboard devices. This should be used instead of the qrcode parsing hack we previously used which is no longer possible on Z-Way 2.3.7.

This closes #1 